### PR TITLE
Fix connection strings

### DIFF
--- a/database_factory/manager.py
+++ b/database_factory/manager.py
@@ -53,7 +53,7 @@ class DatabaseManager(object):
     def __init__(self,
                  engine_type: str,
                  database: str,
-                 sqlite_db_path: str = os.environ["HOME"],
+                 sqlite_db_path: str = os.environ["HOMEPATH"],
                  username: str = None,
                  password: str = None,
                  schema: str = "public",
@@ -241,7 +241,7 @@ class DatabaseManager(object):
             uri = 'sqlite:///' + os.path.join(self.sqlite_db_path,
                                               f"{self.database}.db")
         elif self.engine_type in ["postgres"]:
-            uri = f"postgres+pg8000://{self.username}:{self.password}@{self.host}:{self.port}/{self.database}"
+            uri = f"postgresql+pg8000://{self.username}:{self.password}@{self.host}:{self.port}/{self.database}"
             param = dict(client_encoding="utf8")
             is_not_dialect_desc = True
         elif self.engine_type in ["mysql", "mariadb"]:


### PR DESCRIPTION
1-The URI should start with postgresql:// instead of postgres://. SQLAlchemy used to accept both, but has removed support for the postgres name.
2-os.environ["HOME"] should be changed to os.environ["HOMEPATH"] as it shows keyerror as following : 

sqlite_db_path: str = os.environ["HOME"],
  File "C:\Python310\lib\os.py", line 679, in __getitem__
    raise KeyError(key) from None
KeyError: 'HOME'
